### PR TITLE
Add websocket capabilities

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
     <div id="root"></div>
 
     
-    <script crossorigin src="https://cdnjs.cloudflare.com/ajax/libs/babel-core/5.8.24/browser.min.js"></script>
+    <script crossorigin src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/6.26.0/babel.min.js"></script>
     <script crossorigin src="https://unpkg.com/react@16/umd/react.production.min.js"></script>
     <script crossorigin src="https://unpkg.com/react-dom@16/umd/react-dom.production.min.js"></script>
     <script src="./js/main.js" type="text/babel"></script>

--- a/js/main.js
+++ b/js/main.js
@@ -3,13 +3,72 @@ const Env = {
     serverPort: "80"
 }
 
-class Communication {
-    constructor(){
-        this.ws = WebSocket(`ws://${Env.serverAddress}:${Env.serverPort}`)
+class Communication extends React.PureComponent {
+    constructor(props){
+        super(props);
+        this.webSocket = null;
+        this.state = { error: null, message: null, isOpen: false}
+
+        this.connect = this.connect.bind(this);
+        this.onOpen = this.onOpen.bind(this);
+        this.onClose = this.onClose.bind(this);
+        this.onMessage = this.onMessage.bind(this);
+        this.onError = this.onError.bind(this);
+    }
+
+    connect (lobbyId) {
+        if (this.webSocket == null || !this.state.isOpen) {
+            this.webSocket = new WebSocket(`ws://${Env.serverAddress}:${Env.serverPort}/${lobbyId}`)
+            this.webSocket.onopen = this.onOpen
+            this.webSocket.onclose = this.onClose
+            this.webSocket.onmessage = this.onMessage
+            this.webSocket.onerror = this.onError
+        }
+    }
+
+    disconnect () {
+        if (this.webSocket != null && this.state.isOpen) {
+            this.webSocket.close();
+        }
+    }
+
+    onOpen (event) {
+        this.setState({ isOpen: true })
+    }
+
+    onClose (event) {
+        this.setState({ isOpen: false })
+    }
+
+    onError (error) {
+        this.setState({ error })
+    }
+
+    onMessage (message) {
+        this.setState({ message })
+    }
+
+    render () {
+        const { children } = this.props;
+
+        const childrenState = { 
+            message: this.state.message, 
+            error: this.state.error, 
+            connect: this.connect, 
+            disconnect: this.disconnect 
+        }
+
+        const childrenWithProps = React.Children.map(children, child =>
+            React.cloneElement(child, childrenState));
+
+        return (
+            <div>{childrenWithProps}</div>
+        )
     }
 }
 
-class JoinForm extends React.Component {
+
+class JoinForm extends React.PureComponent {
     constructor(props) {
         super(props);
         this.state = { nick: '', password: '' };
@@ -63,15 +122,26 @@ function Greeting() {
     </p>
 }
 
-function JoinScreen() {
+function JoinScreen(props) {
     return <div>
         <Header />
         <Greeting />
-        <JoinForm />
+        <JoinForm {...props}/>
     </div>
 }
 
+function getCurrentScreen() {
+    //TODO navigate to other screen when some condition changed
+    return <JoinScreen />
+}
+
+const App = () => (
+    <Communication>
+        { getCurrentScreen() }
+    </Communication>
+)
+
 ReactDOM.render(
-    <JoinScreen />,
+    <App />,
     document.getElementById('root')
 );

--- a/js/main.js
+++ b/js/main.js
@@ -76,6 +76,7 @@ class JoinForm extends React.PureComponent {
         this.handleChangeNick = this.handleChangeNick.bind(this);
         this.handleChangePassword = this.handleChangePassword.bind(this);
         this.handleSubmit = this.handleSubmit.bind(this);
+        this.doLogin = this.doLogin.bind(this);
     }
 
     handleChangeNick(event) {
@@ -85,11 +86,32 @@ class JoinForm extends React.PureComponent {
     handleChangePassword(event) {
         this.setState({ password: event.target.value });
     }
+    
+    async doLogin () {
+        try {
+            const options = {
+                method: "POST",
+                body: JSON.stringify({ password: this.state.password })
+            }
+            const response = await fetch(`http://${Env.serverAddress}:${Env.serverPort}/lobby-enter`, options)
+            return JSON.parse(response).lobby
+        } catch(e) {
+            console.log(e);
+            return false;
+        }
+    }
 
-    handleSubmit(event) {
-        // TODO: Join a game.
-        alert(`Information was submitted: ${this.state.nick} and ${this.state.password}`);
+    async handleSubmit(event) {
         event.preventDefault();
+        try { 
+            const lobby = await this.doLogin();
+            if(lobby) {
+                this.props.connect(lobby);
+                // TODO if connection succeeded we need to send a SET NICK websocket event
+            }
+        } catch(e) {
+            console.log(e);
+        }
     }
 
     render() {


### PR DESCRIPTION
This PR adds websocket capabilities wrapped on a [Communication](https://github.com/ArtifactGames/copyplash-web-client/blob/16e2201aeeb0468dfbbc9f3b40e8f0b88924c39d/js/main.js#L6) component.

Explanation of the changes and parts that may not be simple at first sight:

#### Communication

- `constructor`: Initialize the websocket results state and binds component methods
- `connect`: it receives a lobby identifier and open a websocket only if the websocket is not initialized or is not opened yet. It also binds event handlers to the component ones.
- `render`: injects websocket state properties and connection/disconnection methods into the children so they are accesible on lower levels.

#### App
It declares a Communication component as a root one, and render the current screen based on some future logic.

#### JoinForm
- `doLogin`: it request an `lobby-enter` to the API with the given lobby password
- `handleSubmit`: calls `doLogin` and then, if the call succeeded, the `Communication.connect` via the injected property.
